### PR TITLE
Fix parsing of the manual reorder

### DIFF
--- a/pyblock2/driver/parser.py
+++ b/pyblock2/driver/parser.py
@@ -338,8 +338,8 @@ def orbital_reorder(fcidump, method='gaopt'):
         midx = np.array(idx)
     elif method.startswith("manual "):
         method = method[len("manual "):]
-        idx = [int(x)
-               for x in open(method[len("manual "):], "r").readline().split()]
+        idx = [int(x)-1
+               for x in open(method, "r").readline().split()]
         f = OrbitalOrdering.evaluate(n_sites, kmat, VectorUInt16(idx))
         idx = np.array(idx)
         midx, mf = idx, f


### PR DESCRIPTION
In the `Reorder.dat` counting starts with 1 and `method` is already redefined on the previous line.