### PR TITLE
add option to use precompiled headers for faster builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ OPTION(APPLE_ACC_SINGLE_PREC "Fix Apple Accelerate single prec" ON)
 OPTION(BUILD_LIB "Build python block2.so" OFF)
 OPTION(BUILD_CLIB "Build C++ block2.so" OFF)
 OPTION(FORCE_LIB_ABS_PATH "Using absolute path when linking libraries" ON)
+OPTION(USE_PCH "Use precompiled headers for faster builds" OFF)
 
 IF (NOT ${USE_DMRG})
     SET(USE_BIG_SITE OFF)
@@ -641,6 +642,12 @@ TARGET_INCLUDE_DIRECTORIES(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
     $<INSTALL_INTERFACE:include>
     ${MKL_INCLUDE_DIR} ${SCI_INCLUDE_DIR})
+
+IF(${USE_PCH})
+    # these will be precompiled if USE_PCH is ON
+    FILE(GLOB COREHDRS src/instantiation/*.hpp)
+    TARGET_PRECOMPILE_HEADERS(${PROJECT_NAME} PRIVATE ${COREHDRS})
+ENDIF()
 
 IF ((NOT APPLE) AND (NOT WIN32))
     TARGET_LINK_LIBRARIES(${PROJECT_NAME} PRIVATE rt)


### PR DESCRIPTION
Three things are done in this PR.

1. The executable, shared library, and Python module are now different CMake targets. Name conflicts are avoided by setting the OUTPUT_NAME property to the correct value. Currently, this should not change anything for users (if it does, that's a mistake). However, with a few more changes to CMakeLists.txt, it should be possible to build multiple targets at once (e.g. the python module and executable together).

2. Add an option (`-DUSE_PCH=ON`) to precompile the headers in src/instantiation/*.hpp. Precompiling these headers can make builds faster if the user has a compiler that supports it. It's disabled by default.

3. In setup.py, the default number of build processes is still 2, but the user can override it by setting the environment variable CMAKE_BUILD_PARALLEL_LEVEL.

Let me know if there are points I overlooked which need to be addressed, or if you have other suggestions / concerns!