### PR TITLE
make sure only the thread that holds the GIL does Python stuff

### DIFF
--- a/src/dmrg/determinant.hpp
+++ b/src/dmrg/determinant.hpp
@@ -391,7 +391,11 @@ struct DeterminantTRIE<S, FL, typename S::is_sz_t>
 #pragma omp parallel num_threads(ntg)
         // depth-first traverse of trie
         while (!ptrs.empty()) {
+#pragma omp master
+        {
             check_signal_()();
+            // the master thread holds the GIL
+        }
             int pstart = max(0, (int)ptrs.size() - ngroup);
 #pragma omp for schedule(static)
             for (int ip = pstart; ip < (int)ptrs.size(); ip++) {
@@ -772,7 +776,11 @@ struct DeterminantTRIE<S, FL, typename S::is_su2_t>
 #pragma omp parallel num_threads(ntg)
         // depth-first traverse of trie
         while (!ptrs.empty()) {
+#pragma omp master
+        {
             check_signal_()();
+            // the master thread holds the GIL
+        }
             int pstart = max(0, (int)ptrs.size() - ngroup);
 #pragma omp for schedule(static)
             for (int ip = pstart; ip < (int)ptrs.size(); ip++) {
@@ -1080,7 +1088,11 @@ struct DeterminantTRIE<S, FL, typename S::is_sg_t>
 #pragma omp parallel num_threads(ntg)
         // depth-first traverse of trie
         while (!ptrs.empty()) {
+#pragma omp master
+        {
             check_signal_()();
+            // the master thread holds the GIL
+        }
             int pstart = max(0, (int)ptrs.size() - ngroup);
 #pragma omp for schedule(static)
             for (int ip = pstart; ip < (int)ptrs.size(); ip++) {
@@ -1451,7 +1463,11 @@ struct DeterminantTRIE<S, FL, typename S::is_sany_t>
 #pragma omp parallel num_threads(ntg)
         // depth-first traverse of trie
         while (!ptrs.empty()) {
+#pragma omp master
+        {
             check_signal_()();
+            // the master thread holds the GIL
+        }
             int pstart = max(0, (int)ptrs.size() - ngroup);
 #pragma omp for schedule(static)
             for (int ip = pstart; ip < (int)ptrs.size(); ip++) {

--- a/src/dmrg/determinant.hpp
+++ b/src/dmrg/determinant.hpp
@@ -392,10 +392,7 @@ struct DeterminantTRIE<S, FL, typename S::is_sz_t>
         // depth-first traverse of trie
         while (!ptrs.empty()) {
 #pragma omp master
-        {
-            check_signal_()();
-            // the master thread holds the GIL
-        }
+        check_signal_()();
             int pstart = max(0, (int)ptrs.size() - ngroup);
 #pragma omp for schedule(static)
             for (int ip = pstart; ip < (int)ptrs.size(); ip++) {
@@ -777,10 +774,7 @@ struct DeterminantTRIE<S, FL, typename S::is_su2_t>
         // depth-first traverse of trie
         while (!ptrs.empty()) {
 #pragma omp master
-        {
-            check_signal_()();
-            // the master thread holds the GIL
-        }
+        check_signal_()();
             int pstart = max(0, (int)ptrs.size() - ngroup);
 #pragma omp for schedule(static)
             for (int ip = pstart; ip < (int)ptrs.size(); ip++) {
@@ -1089,10 +1083,7 @@ struct DeterminantTRIE<S, FL, typename S::is_sg_t>
         // depth-first traverse of trie
         while (!ptrs.empty()) {
 #pragma omp master
-        {
-            check_signal_()();
-            // the master thread holds the GIL
-        }
+        check_signal_()();
             int pstart = max(0, (int)ptrs.size() - ngroup);
 #pragma omp for schedule(static)
             for (int ip = pstart; ip < (int)ptrs.size(); ip++) {
@@ -1464,10 +1455,7 @@ struct DeterminantTRIE<S, FL, typename S::is_sany_t>
         // depth-first traverse of trie
         while (!ptrs.empty()) {
 #pragma omp master
-        {
-            check_signal_()();
-            // the master thread holds the GIL
-        }
+        check_signal_()();
             int pstart = max(0, (int)ptrs.size() - ngroup);
 #pragma omp for schedule(static)
             for (int ip = pstart; ip < (int)ptrs.size(); ip++) {

--- a/src/dmrg/determinant.hpp
+++ b/src/dmrg/determinant.hpp
@@ -392,7 +392,7 @@ struct DeterminantTRIE<S, FL, typename S::is_sz_t>
         // depth-first traverse of trie
         while (!ptrs.empty()) {
 #pragma omp master
-        check_signal_()();
+            check_signal_()();
             int pstart = max(0, (int)ptrs.size() - ngroup);
 #pragma omp for schedule(static)
             for (int ip = pstart; ip < (int)ptrs.size(); ip++) {
@@ -774,7 +774,7 @@ struct DeterminantTRIE<S, FL, typename S::is_su2_t>
         // depth-first traverse of trie
         while (!ptrs.empty()) {
 #pragma omp master
-        check_signal_()();
+            check_signal_()();
             int pstart = max(0, (int)ptrs.size() - ngroup);
 #pragma omp for schedule(static)
             for (int ip = pstart; ip < (int)ptrs.size(); ip++) {
@@ -1083,7 +1083,7 @@ struct DeterminantTRIE<S, FL, typename S::is_sg_t>
         // depth-first traverse of trie
         while (!ptrs.empty()) {
 #pragma omp master
-        check_signal_()();
+            check_signal_()();
             int pstart = max(0, (int)ptrs.size() - ngroup);
 #pragma omp for schedule(static)
             for (int ip = pstart; ip < (int)ptrs.size(); ip++) {
@@ -1455,7 +1455,7 @@ struct DeterminantTRIE<S, FL, typename S::is_sany_t>
         // depth-first traverse of trie
         while (!ptrs.empty()) {
 #pragma omp master
-        check_signal_()();
+            check_signal_()();
             int pstart = max(0, (int)ptrs.size() - ngroup);
 #pragma omp for schedule(static)
             for (int ip = pstart; ip < (int)ptrs.size(); ip++) {


### PR DESCRIPTION
This is one way to resolve #106.

You could also redefine
```
    check_signal_() = []() {
        PyGILState_STATE gstate;
        gstate = PyGILState_Ensure();
        if (PyErr_CheckSignals() != 0)
            throw py::error_already_set();
        PyGILState_Release(gstate);
    };
```