### PR TITLE
docs: fix -DOMP_LIB examples and clean up user-facing typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can find a bibtex file in [`CITATIONS.bib`](https://github.com/block-hczhai/
 
 For a list of DMRG references for methods implemented in ``block2``, see: https://block2.readthedocs.io/en/latest/user/references.html.
 
-One can install ``block2`` using ``pip`` (note: for very new Python versions, the ``--extra-index-url`` option of ``pip`` is required, see below for installing the developement version of ``block2``):
+One can install ``block2`` using ``pip`` (note: for very new Python versions, the ``--extra-index-url`` option of ``pip`` is required, see below for installing the development version of ``block2``):
 
 * OpenMP-only version (no MPI dependence)
 
@@ -166,7 +166,7 @@ StackBlock Compatibility
 A [StackBlock 1.5](https://github.com/sanshar/StackBlock) compatible user interface can be found at `pyblock2/driver/block2main`.
 This script can work as a replacement of the StackBlock binary, with a few limitations and some extensions.
 The format of the input file `dmrg.conf` is identical to that of StackBlock 1.5.
-See `docs/driver.md` and `docs/source/user/basic.rst` for detailed documentations for this interface.
+See `docs/driver.md` and `docs/source/user/basic.rst` for detailed documentation for this interface.
 Examples using this interface can be found at `tests/driver`.
 
-Instuctions for installing the StackBlock code can be found in [here](https://block2.readthedocs.io/en/latest/user/mps-io.html#stackblock-installation). A list of precompiled binaries of StackBlock can be found in [here](https://github.com/hczhai/StackBlock/releases/tag/v1.5.3).
+Instructions for installing the StackBlock code can be found in [here](https://block2.readthedocs.io/en/latest/user/mps-io.html#stackblock-installation). A list of precompiled binaries of StackBlock can be found in [here](https://github.com/hczhai/StackBlock/releases/tag/v1.5.3).

--- a/docs/source/user/basic.rst
+++ b/docs/source/user/basic.rst
@@ -31,7 +31,7 @@ The following python script is used as the "block2 executable": ::
     ${BLOCK2HOME}/pyblock2/driver/block2main
 
 where ``${BLOCK2HOME}`` is the ``block2`` root directory. The root directory and ``build`` directory under ``block2``
-root directory should be in ``PYTHONPATH``. You can add the following line in your environemnt
+root directory should be in ``PYTHONPATH``. You can add the following line in your environment
 (such as ``~/.bashrc``) or submission script: ::
 
     export PYTHONPATH=${BLOCK2HOME}:${BLOCK2HOME}/build:${PYTHONPATH}

--- a/docs/source/user/installation.rst
+++ b/docs/source/user/installation.rst
@@ -23,11 +23,11 @@ One can install ``block2`` using ``pip``:
   If these binaries have some problems, you can use the ``--no-binary`` option of ``pip`` to force building from source
   (for example, ``pip install block2 --no-binary block2``).
 
-* For very new Python versions, the ``--extra-index-url`` option of ``pip`` is required, see below for installing the developement version of ``block2``.
+* For very new Python versions, the ``--extra-index-url`` option of ``pip`` is required, see below for installing the development version of ``block2``.
 
 * One should only install one of ``block2`` and ``block2-mpi``. ``block2-mpi`` covers all features in ``block2``,
   but its dependence on mpi library can sometimes be difficult to deal with.
-  Some guidance for resolving environment problems can be found in github issue
+  Some guidance for resolving environment problems can be found in GitHub issue
   `#7 <https://github.com/block-hczhai/block2-preview/issues/7>`_.
 
 * To install the most recent development version, use: ::
@@ -242,7 +242,7 @@ Sometimes, when you have to use ``block2`` together with other python modules (s
 it may have some problem coexisting with each other.
 In general, change the import order may help.
 For ``pyscf``, ``import block2`` at the very beginning of the script may help.
-For ``pyblock``, recompiling ``block2`` use ``cmake .. -DUSE_MKL=OFF -DBUILD_LIB=ON -OMP_LIB=SEQ -DLARGE_BOND=ON`` may help.
+For ``pyblock``, recompiling ``block2`` use ``cmake .. -DUSE_MKL=OFF -DBUILD_LIB=ON -DOMP_LIB=SEQ -DLARGE_BOND=ON`` may help.
 
 Using C++ Interpreter cling
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -250,6 +250,6 @@ Using C++ Interpreter cling
 Since ``block2`` is designed as a header-only C++ library, it can be conveniently executed
 using C++ interpreter `cling <https://github.com/root-project/cling>`_
 (which can be installed via `anaconda <https://anaconda.org/conda-forge/cling>`_)
-without any compilation. This can be useful for testing samll changes in the C++ code.
+without any compilation. This can be useful for testing small changes in the C++ code.
 
 Example C++ code for ``cling`` can be found at ``tests/cling/hubbard.cl``.

--- a/docs/source/user/mps-io.rst
+++ b/docs/source/user/mps-io.rst
@@ -162,14 +162,14 @@ The energy for the MPS that will be translated is the energy at the last site of
     $ grep 'sweep energy' dmrg.out | tail -1
     Finished Sweep with 500 states and sweep energy for State [ 0 ] with Spin [ 0 ] :: -75.728442606745
 
-Since in the default schedule the one-site algorithm is used for the last sweep. This two energies are identical.
+Since in the default schedule the one-site algorithm is used for the last sweep. These two energies are identical.
 
 Now the MPS in ``StackBlock`` format is stored in the scratch folder ``./tmp/node0``.
 We will only need files in this folder with file names ``Rotation-*``, ``StateInfo-*``, ``wave-*``.
 The other files ``Block-b-*`` and ``Block-f-*`` (with renormalized operators stored)
 are not part of the MPS, which can be deleted.
 
-The folowing commands can be used to translate the MPS.
+The following commands can be used to translate the MPS.
 Please make sure that the environment variables ``${STACKBLOCK}``, ``${PYBLOCKHOME}``, and ``${BLOCK2HOME}``
 are correctly set. ::
 
@@ -183,11 +183,11 @@ are correctly set. ::
 .. note ::
     Here we use a special build of ``block2`` python extension,
     which was built using the ``cmake`` option ``-DTBB=OFF`` (the default is ``OFF``).
-    On some systems ``-DUSE_MKL=OFF -OMP_LIB=SEQ`` may be required.
+    On some systems ``-DUSE_MKL=OFF -DOMP_LIB=SEQ`` may be required.
     This is to solve the conflicts for importing ``pyblock`` and ``block2`` in the same script.
 
 Note that ``-expect`` option is optional. With this option, the energy of the translated MPS
-will be evaluted in ``block2`` and printed.
+will be evaluated in ``block2`` and printed.
 We can see that the printed ``block2`` energy is almost exactly the same as the one obtained from
 ``StackBlock``.
 By default, the translated ``block2`` MPS will be put in the output directory named


### PR DESCRIPTION
## Summary
This PR combines two small documentation improvements aimed at first-time users:

- Fixes two incorrect CMake flag examples by replacing -OMP_LIB=SEQ with -DOMP_LIB=SEQ
- Cleans up several user-facing typos in README and user docs

## Why this is useful
- Prevents copy/paste configuration errors for users compiling from source
- Improves clarity and polish of top-level documentation with zero runtime impact

## Files changed
- README.md
- docs/source/user/basic.rst
- docs/source/user/installation.rst
- docs/source/user/mps-io.rst

## Notes
- Docs-only change (no source code behavior changes)
- No breaking changes

## Checklist
- [x] Small, focused changes
- [x] Kept scope to documentation only
- [x] Verified both -OMP_LIB=SEQ occurrences are corrected